### PR TITLE
Strings for serial port definition

### DIFF
--- a/macros/ARDUINO_SETUP.sci
+++ b/macros/ARDUINO_SETUP.sci
@@ -34,10 +34,10 @@ function [x, y, typ]=ARDUINO_SETUP(job, arg1, arg2)
         model=arg1.model;
 
         while %t do
-  
+
             [ok,num_arduino,port_com,exprs]=scicos_getvalue('Arduino Setup parameters',..
-            [gettext('Identifier of Arduino card'),gettext('Serial com port number')],..
-            list('vec',1,'vec',1), ..
+            [gettext('Identifier of Arduino card'),gettext('Serial com port')],..
+            list('vec',1,'str',-1), ..
             exprs)
             mess=[];
 
@@ -49,15 +49,16 @@ function [x, y, typ]=ARDUINO_SETUP(job, arg1, arg2)
                 mess=[mess ;gettext("Only "+string(maxboard)+" can be used with this toolbox version ")];
                 ok=%f;
             end
-    
-            // Remove 
+
+            // Remove
 //            if port_com > 9 then // 20191016-TCL: Removed restriction on 0 and 1 for linux compatible - consider to add back for windows.
 //                mess=[gettext("Serial port must not be greater than 9. Change in the pannel configuration / Port com ")];
 //                ok=%f;
-//            end 
+//            end
 
             if ok then// Everything's ok
-                model.rpar=[num_arduino,port_com];
+                model.rpar=[num_arduino];
+                model.opar=list(port_com);
                 graphics.exprs = exprs;
                 x.model=model;
                 x.graphics = graphics;
@@ -75,8 +76,9 @@ function [x, y, typ]=ARDUINO_SETUP(job, arg1, arg2)
         model.dep_ut=[%f %f];
         model.in=[];
         num_arduino=1;
-        port_com=5;
-        model.rpar=[num_arduino,port_com]; //Digital Output number
+        port_com='5';
+        model.rpar=[num_arduino]; //Digital Output number
+        model.opar=list(port_com);
         x=standard_define([2 2],model,[],[]);
         x.graphics.in_implicit=[];
         x.graphics.style= msprintf(style, string(num_arduino), string(port_com))

--- a/macros/init_arduino.sci
+++ b/macros/init_arduino.sci
@@ -43,7 +43,10 @@ function []=init_arduino(scs_m, needcompile)
     // Passe en revue tous les blocs pour relever dans des tableaux chacun des types de blocs
     for i=1:nombre_blocs
         if objs(i).gui=="ARDUINO_SETUP" then nb_arduino=nb_arduino+1;
-            port_com_arduino(objs(i).model.rpar(1))=objs(i).model.rpar(2); //on stocke le numero du com de la carte numerotée dans le bloc
+            port_com_arduino(objs(i).model.rpar(1))=objs(i).model.opar(1); //on stocke le numero du com de la carte numerotée dans le bloc
+            if isnum(port_com_arduino(i)) then
+                port_com_arduino(i) = strtod(port_com_arduino(i));
+            end
         end
         //pour chaque bloc on releve le pin indiqué et on le stocke dans la catégorie correspondante
         rep=find(objs(i).gui==list_arduino_gui);
@@ -152,23 +155,3 @@ function []=init_arduino(scs_m, needcompile)
 
     disp("Initialization done")
 endfunction
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/sci_gateway/c/main_linux.c
+++ b/sci_gateway/c/main_linux.c
@@ -109,13 +109,23 @@ int open_serial(scilabEnv env, int nin, scilabVar* in, int nopt, scilabOpt* opt,
 	scilab_getDouble(env, in[0], &handle);
 	int int_handle = (int)handle;
 
-	//in[1] : Double
+	//in[1] : Double or String
+  char portname[32];
 	if (scilab_isDouble(env, in[1]) == 0 || scilab_isScalar(env, in[1]) == 0)
 	{
-		Scierror(77, "Wrong type for input argument %d: A double expected.\n", 2);
-		return -1;
-	}
-	scilab_getDouble(env, in[1], &port);
+    if (scilab_isString(env, in[1]) == 0 || scilab_isScalar(env, in[1]) == 0)
+    {
+  		Scierror(77, "Wrong type for input argument %d: A double or string expected.\n", 2);
+	  	return -1;
+    }
+    wchar_t* str = 0;
+    scilab_getString(env, in[1], &str);
+    wcstombs(portname, str, 2*sizeof(portname-1));
+
+	}else{
+  	scilab_getDouble(env, in[1], &port);
+    sprintf(portname, "/dev/ttyACM%d", (int)port);
+  }
 
 	//in[2] : Double
 	if (scilab_isDouble(env, in[2]) == 0 || scilab_isScalar(env, in[2]) == 0)
@@ -125,18 +135,6 @@ int open_serial(scilabEnv env, int nin, scilabVar* in, int nopt, scilabOpt* opt,
 	}
 	scilab_getDouble(env, in[2], &baudrate);
 
-	char *portname;
-		switch((int)port){
-		case 0: portname = "//dev/ttyACM0";break;
-		case 1: portname = "//dev/ttyACM1";break;
-                case 2: portname = "//dev/ttyACM2";break;
-                case 3: portname = "//dev/ttyACM3";break;
-                case 4: portname = "//dev/ttyACM4";break;
-                case 5: portname = "//dev/ttyACM5";break;
-                case 6: portname = "//dev/ttyACM6";break;
-                case 7: portname = "//dev/ttyACM7";break;
-		default : return;
-	}
 	*OK = 0;
 	handleport[int_handle] = open (portname, O_RDWR | O_NOCTTY | O_SYNC);
 	//fd = open (portname, O_RDWR | O_NOCTTY); //srikant
@@ -371,5 +369,3 @@ int read_serial(scilabEnv env, int nin, scilabVar* in, int nopt, scilabOpt* opt,
 	return 0;
 
 }
-
-


### PR DESCRIPTION
I noticed that for Linux only devices with '/dev/ttyACMx' can be used. I got an cheap Arduino Nano here and it is connected to my PC as '/dev/ttyUSB0'. I added the option to give the device instead of the number. See here:

![image](https://user-images.githubusercontent.com/2740778/77771758-681de500-7047-11ea-9f8d-32854fb78b01.png)

As far as I can test it the old scheme with the number still works.

I also changed the numbering so any number can be given. 13 would lead to '/dev/ttyACM13' for example.