### PR TITLE
Rework serial port routines

### DIFF
--- a/macros/ARDUINO_SETUP.sci
+++ b/macros/ARDUINO_SETUP.sci
@@ -36,8 +36,8 @@ function [x, y, typ]=ARDUINO_SETUP(job, arg1, arg2)
         while %t do
   
             [ok,num_arduino,port_com,exprs]=scicos_getvalue('Arduino Setup parameters',..
-            [gettext('Identifier of Arduino card'),gettext('Serial com port number')],..
-            list('vec',1,'vec',1), ..
+            [gettext('Identifier of Arduino card'),gettext('Serial port')],..
+            list('vec',1,'str',1), ..
             exprs)
             mess=[];
 
@@ -50,14 +50,9 @@ function [x, y, typ]=ARDUINO_SETUP(job, arg1, arg2)
                 ok=%f;
             end
     
-            // Remove 
-//            if port_com > 9 then // 20191016-TCL: Removed restriction on 0 and 1 for linux compatible - consider to add back for windows.
-//                mess=[gettext("Serial port must not be greater than 9. Change in the pannel configuration / Port com ")];
-//                ok=%f;
-//            end 
-
             if ok then// Everything's ok
-                model.rpar=[num_arduino,port_com];
+                model.rpar=[num_arduino];
+                model.opar=list(port_com);
                 graphics.exprs = exprs;
                 x.model=model;
                 x.graphics = graphics;
@@ -75,8 +70,9 @@ function [x, y, typ]=ARDUINO_SETUP(job, arg1, arg2)
         model.dep_ut=[%f %f];
         model.in=[];
         num_arduino=1;
-        port_com=5;
-        model.rpar=[num_arduino,port_com]; //Digital Output number
+        port_com="COM5";
+        model.rpar=[num_arduino];
+        model.opar=list(port_com);
         x=standard_define([2 2],model,[],[]);
         x.graphics.in_implicit=[];
         x.graphics.style= msprintf(style, string(num_arduino), string(port_com))

--- a/macros/ARDUINO_pre_simulate.sci
+++ b/macros/ARDUINO_pre_simulate.sci
@@ -30,7 +30,7 @@ function scs_m=ARDUINO_pre_simulate(scs_m, needcompile)
                 
                 sleep(1000)
                 handle_num=scs_m.objs(i).model.rpar(1) // 20191014: CL: Add to get the handle number to differentiate the boards.
-                port_com_arduino=scs_m.objs(i).model.rpar(2)
+                port_com_arduino=scs_m.objs(i).model.opar(1)
                 //port_com=openserial(port_com_arduino,"115200,n,8,1"); //ouverture du port com de la carte i
                 //ok=open_serial(1,port_com_arduino,115200); //ouverture du port COM de l'arduino i
                 handle_str = 'h'+string(handle_num);
@@ -75,9 +75,11 @@ function scs_m=ARDUINO_pre_simulate(scs_m, needcompile)
                 //write_serial(1,ascii(201)+ascii(201),2); // utilité ?
             catch
                 funcprot(old_funcprot)
+                disp(lasterror())
                 close_serial(evstr(handle_str))
                 // error('Mauvais port de communication.')
                 error('Bad communication port.');
+                return
             end
         end
         if (typeof(curObj) == "Block" & curObj.gui == "TIME_SAMPLE") then

--- a/macros/init_arduino.sci
+++ b/macros/init_arduino.sci
@@ -21,7 +21,7 @@ function []=init_arduino(scs_m, needcompile)
     nombre_blocs=0;    //Nombre de blocs dans le diagramme
     nombre_liens=0;    //Nombre de lien dans le diagramme
     nb_arduino=0; //nombre de cartes arduino
-    port_com_arduino=[];    //numero des ports com associes a chaque carte arduino
+    port_com_arduino=list();    //numero des ports com associes a chaque carte arduino
 
     //liste des types de blocs arduino
     list_arduino_gui=["ARDUINO_DIGITAL_WRITE","ARDUINO_DIGITAL_READ","ARDUINO_ANALOG_WRITE","ARDUINO_ANALOG_READ","ARDUINO_DCMOTOR","ARDUINO_SERVO_WRITE","ARDUINO_SERVO_READ","ARDUINO_STEPPER","ARDUINO_ENCODER"];
@@ -43,7 +43,7 @@ function []=init_arduino(scs_m, needcompile)
     // Passe en revue tous les blocs pour relever dans des tableaux chacun des types de blocs
     for i=1:nombre_blocs
         if objs(i).gui=="ARDUINO_SETUP" then nb_arduino=nb_arduino+1;
-            port_com_arduino(objs(i).model.rpar(1))=objs(i).model.rpar(2); //on stocke le numero du com de la carte numerotée dans le bloc
+            port_com_arduino(objs(i).model.rpar(1))=objs(i).model.opar(1); //on stocke le numero du com de la carte numerotée dans le bloc
         end
         //pour chaque bloc on releve le pin indiqué et on le stocke dans la catégorie correspondante
         rep=find(objs(i).gui==list_arduino_gui);
@@ -66,6 +66,8 @@ function []=init_arduino(scs_m, needcompile)
     catch
         messagebox("Wrong communication port")
         error("Wrong communication port")
+        disp(lasterror())
+        return
     end
     //configuration des Pin Pout
     try

--- a/macros/nicescope.sci
+++ b/macros/nicescope.sci
@@ -4,7 +4,7 @@ function []=nicescope()
     list_fig=winsid();  // On récupere les numéros des figure
 
     for i=1:length(list_fig)
-        h=get_figure_handle(list_fig(i));
+        h=findobj('figure_id',list_fig(i))
         scf(h);
         //En cas de simulation param_var
         if (h.tag=="todemux") then

--- a/sci_gateway/c/builder_gateway_c.sce
+++ b/sci_gateway/c/builder_gateway_c.sce
@@ -7,8 +7,10 @@ function builder_gw_c()
 
     if getos() == "Windows"
         gw_c_files = findfiles(gw_c_path, '*_win.c');
+        gw_c_flags = "/W3 /WX"
     else
         gw_c_files = findfiles(gw_c_path, '*_linux.c');
+        gw_c_flags = "-Wall -Wextra -Werror"
     end
 
     func = ['open_serial','open_serial','csci6';...
@@ -22,7 +24,8 @@ function builder_gw_c()
     gw_c_files, ..
     gw_c_path, ..
     "", ..
-    "");
+    "", ..
+    gw_c_flags);
 
 
 endfunction


### PR DESCRIPTION
Changes:
 * Fixed usage of deprecated `get_figure_handle()` on 6.1.1
 * Turned on compiler warnings for gateway files
 * Made port name/number a string, not an integer
 * On Windows port may be defined by its name or number
 * All port numbers are accessible on Windows: `COM1`..`COM255`
 * On Linux port name should be a full device path e.g. `/dev/ttyUSB5`
 * More error checking and handling.
 * Better error messages for syscalls errors
 * No more memory leaks due to unused `OK` variables
 * No more static storage for port handlers: native handler (or file
   descriptor on Linux) is returned to Scilab and received from it;
   Number of boards used is no more limited
 * Disabled flow control configuration on Windows

Tested with Scilab 6.1.1 on Windows 10 64bit (MSVC v142 Community Edition) and Linux64 (GCC v11.2).
Symlinks were tested and work perfectly fine on Linux.

This change was developed fully independently from https://github.com/tanchinluh/arduino/pull/1 and they overlap a bit, but this change has much greater level of rework for the sci_gateway code.